### PR TITLE
Fix: link checking failing in continuous builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build
-    - run: npm run test:lint
+    - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-lit": "^1.14.0",
         "eslint-plugin-wc": "^2.1.0",
         "hygen": "^6.2.11",
-        "linkinator": "^6.0.6",
+        "linkinator": "^6.1.0",
         "luxon": "^3.4.4",
         "markdown-it-eleventy-img": "^0.10.2",
         "stylelint": "^16.6.1",
@@ -5574,9 +5574,9 @@
       }
     },
     "node_modules/linkinator": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-6.0.6.tgz",
-      "integrity": "sha512-5Hc0qIB8pSXeNQej30ruUHqu37gbJf8o3tu4qNeJCZX9/jZ80BkOrRhst3fR9ipizLFy24HgKmqCFilGOrtZjQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-6.1.0.tgz",
+      "integrity": "sha512-Snumf1hRc9VycBhjMQS2nkc7NHc7OnBD66zSajSbttv+AvbpqV/HeaDJPxHLJl1TTSmfdjMLOYC8wedowKdpag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-lit": "^1.14.0",
     "eslint-plugin-wc": "^2.1.0",
     "hygen": "^6.2.11",
-    "linkinator": "^6.0.6",
+    "linkinator": "^6.1.0",
     "luxon": "^3.4.4",
     "markdown-it-eleventy-img": "^0.10.2",
     "stylelint": "^16.6.1",


### PR DESCRIPTION
The link checking step was failing in continuous builds because access to the grislyeye.com domain was failing with 403s:

https://github.com/grislyeye/grislyeye.com/actions/runs/9745764627/job/26894500329

This was caused by Cloudflare's Bot Fight Mode being enabled:

https://developers.cloudflare.com/bots/#bot-fight-mode